### PR TITLE
Update support for `symfony` dependancies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
   ],
   "require": {
     "php": ">=7.1.3",
-    "symfony/dom-crawler": "^3.0.0",
-    "symfony/css-selector": "^3.0.0",
+    "symfony/dom-crawler": "^3.0|^4.0|^5.0|^6.0",
+    "symfony/css-selector": "^3.0|^4.0|^5.0|^6.0",
     "league/commonmark": "^1.0"
   },
   "require-dev": {


### PR DESCRIPTION
This package is unable to be installed with a few plugins I'm working on that require more up to date versions of `symfony/dom-crawler` and `symfony/css-selector`. This is also an issue when installing https://plugins.craftcms.com/retcon

I don't believe there are any major changes that Changelog needs to be aware of from v3 to v6.